### PR TITLE
Update Node.java

### DIFF
--- a/jme3-core/src/main/java/com/jme3/scene/Node.java
+++ b/jme3-core/src/main/java/com/jme3/scene/Node.java
@@ -570,14 +570,7 @@ public class Node extends Spatial {
         // optimization: try collideWith BoundingVolume to avoid possibly redundant tests on children
         // number 4 in condition is somewhat arbitrary. When there is only one child, the boundingVolume test is redundant at all. 
         // The idea is when there are few children, it can be too expensive to test boundingVolume first.
-        if (children.size() > 4)
-        {
-          BoundingVolume bv = this.getWorldBound();
-          if (bv==null) return 0;
-
-          // collideWith without CollisionResults parameter used to avoid allocation when possible
-          if (bv.collideWith(other) == 0) return 0;
-        }
+        
         for (Spatial child : children.getArray()){
             total += child.collideWith(other, results);
         }


### PR DESCRIPTION
Remove these four lines from Node.CollideWith. It makes exceptions when the node has more then 3 children. These lines are new in 3.1
